### PR TITLE
Ajout de la vérification des headers de réponse

### DIFF
--- a/testapi/src/main/java/org/requests/payload/request/Answer.java
+++ b/testapi/src/main/java/org/requests/payload/request/Answer.java
@@ -1,6 +1,7 @@
 package org.requests.payload.request;
 
 import java.io.Serializable;
+import java.util.List;
 
 public class Answer implements Serializable {
     public int expectedStatusCode;
@@ -8,4 +9,7 @@ public class Answer implements Serializable {
     public String expectedOutput;
     public String output;
     public boolean answer;
+
+    // Human-readable messages that explain why "answer" is false
+    public List<String> messages;
 }

--- a/testapi/src/main/java/org/requests/payload/request/TestApiRequest.java
+++ b/testapi/src/main/java/org/requests/payload/request/TestApiRequest.java
@@ -2,6 +2,7 @@ package org.requests.payload.request;
 
 import org.requests.Method;
 import javax.validation.constraints.NotBlank;
+import java.util.Map;
 
 public class TestApiRequest {
     private Method method;
@@ -16,6 +17,8 @@ public class TestApiRequest {
     private String expectedOutput;
 
     private int responseTime;
+
+    private Map<String, String> expectedHeaders;
 
     public Method getMethod() { return this.method; }
     public void setMethod(String method) { this.method = Method.valueOf(method.toUpperCase()); }
@@ -38,6 +41,14 @@ public class TestApiRequest {
 
     public void setResponseTime(int responseTime) {
         this.responseTime = responseTime;
+    }
+
+    public Map<String, String> getExpectedHeaders() {
+        return expectedHeaders;
+    }
+
+    public void setExpectedHeaders(Map<String, String> expectedHeaders) {
+        this.expectedHeaders = expectedHeaders;
     }
 }
 


### PR DESCRIPTION
J'ai également ajouté un mécanisme pour collecter des message dans les methodes `check*`, à destination d'un humain qui voudrait comprendre pourquoi "answer" vaut `false`. Si ça peut intéresser, je peux implémenter ces vérifications pour les autres checks déjà présents (soit dans cette PR ou dans une suivante).